### PR TITLE
Custom tab rendering

### DIFF
--- a/packages/core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/core/src/components/Tabs/Tabs.test.tsx
@@ -74,4 +74,20 @@ describe('Tabs', () => {
       expect(tab.prop('variant')).toEqual('outline');
     });
   });
+
+  it('should handle renderTab prop', () => {
+    const renderTab = jest.fn().mockImplementation((tab, key) => {
+      return <a key={key}>{tab}</a>;
+    });
+
+    wrapper = mount(
+      <ThemeProvider theme={baseTheme}>
+        <Tabs tabs={tabs} variant="outline" renderTab={renderTab} />
+      </ThemeProvider>
+    );
+
+    expect(renderTab).toHaveBeenCalled();
+    expect(wrapper.find('a').length).toEqual(2);
+    expect(wrapper.find(Tab).length).toEqual(2);
+  });
 });

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -9,6 +9,7 @@ export interface ITabsProps {
   activeTab?: number;
   onTabChange?: (event: React.SyntheticEvent, id: number) => void;
   variant?: string;
+  renderTab?: (tab: React.ReactNode, key: number) => React.ReactNode;
 }
 
 export const Tabs = (props: ITabsProps) => {
@@ -20,15 +21,21 @@ export const Tabs = (props: ITabsProps) => {
 
   const renderTabs =
     props.children ||
-    props.tabs.map((tabProps, idx) => (
-      <Tab
-        key={idx}
-        {...tabProps}
-        active={props.activeTab === idx}
-        variant={props.variant}
-        onClick={handleTabChange(idx)}
-      />
-    ));
+    props.tabs.map((tabProps, idx) => {
+      const tab = (
+        <Tab
+          key={idx}
+          {...tabProps}
+          active={props.activeTab === idx}
+          variant={props.variant}
+          onClick={handleTabChange(idx)}
+        />
+      );
+      if (props.renderTab) {
+        return props.renderTab(tab, idx);
+      }
+      return tab;
+    });
 
   const flexDirection = props.vertical ? 'column' : 'row';
 


### PR DESCRIPTION
Add a `renderTab` prop so that users can easily wrap tabs in links or do any other custom rendering that might be necessary for a given application.